### PR TITLE
Enable multiple edge deployments against the same controller

### DIFF
--- a/gcpnetwork.tf
+++ b/gcpnetwork.tf
@@ -86,7 +86,7 @@ resource "google_compute_forwarding_rule" "forwarding_rule" {
 }
 
 resource "google_compute_route" "avx-edge-rfc10" {
-  name         = "avx-edge-rfc10"
+  name         = "${var.pov_prefix}-edge-rfc10"
   dest_range   = "10.0.0.0/8"
   network      = google_compute_network.vpc_network.name
   next_hop_ilb = google_compute_forwarding_rule.forwarding_rule.id
@@ -94,7 +94,7 @@ resource "google_compute_route" "avx-edge-rfc10" {
 }
 
 resource "google_compute_route" "avx-edge-rfc172" {
-  name         = "avx-edge-rfc172"
+  name         = "${var.pov_prefix}-edge-rfc172"
   dest_range   = "172.16.0.0/12"
   network      = google_compute_network.vpc_network.name
   next_hop_ilb = google_compute_forwarding_rule.forwarding_rule.id
@@ -102,7 +102,7 @@ resource "google_compute_route" "avx-edge-rfc172" {
 }
 
 resource "google_compute_route" "avx-edge-rfc192" {
-  name         = "avx-edge-rfc192"
+  name         = "${var.pov_prefix}-edge-rfc192"
   dest_range   = "192.168.0.0/16"
   network      = google_compute_network.vpc_network.name
   next_hop_ilb = google_compute_forwarding_rule.forwarding_rule.id


### PR DESCRIPTION
Add `pov_prefix` to rfc1918 routes to avoid collision when more than one edge is deployed.