### PR TITLE
Enhancements for 7.1/3.1.0 and lab deployments

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "main"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "githubPullRequests.ignoredPullRequestBranches": [
-        "main"
-    ]
-}

--- a/avxedge.tf
+++ b/avxedge.tf
@@ -1,6 +1,6 @@
 # Deploy Avx Edge Gateways in Controller, download ZTP.
 
-resource "aviatrix_edge_spoke" "edge" {
+resource "aviatrix_edge_vm_selfmanaged" "edge" {
   for_each = local.host_vms
 
   gw_name                          = each.value.edge_vm
@@ -60,7 +60,7 @@ resource "aviatrix_edge_spoke_external_device_conn" "to_host_vm" {
 
   depends_on = [
     google_compute_instance.host_vm,
-    aviatrix_edge_spoke.edge
+    aviatrix_edge_vm_selfmanaged.edge
   ]
 }
 
@@ -78,6 +78,6 @@ resource "aviatrix_edge_spoke_transit_attachment" "to_transit_gw" {
 
   depends_on = [
     google_compute_instance.host_vm,
-    aviatrix_edge_spoke.edge
+    aviatrix_edge_vm_selfmanaged.edge
   ]
 }

--- a/avxedge.tf
+++ b/avxedge.tf
@@ -3,10 +3,11 @@
 resource "aviatrix_edge_spoke" "edge" {
   for_each = local.host_vms
 
-  gw_name                = each.value.edge_vm
-  site_id                = local.pov_edge_site
-  ztp_file_type          = "iso"
-  ztp_file_download_path = "${path.root}/${each.key}/"
+  gw_name                          = each.value.edge_vm
+  site_id                          = local.pov_edge_site
+  ztp_file_type                    = "iso"
+  ztp_file_download_path           = "${path.root}/${each.key}/"
+  management_egress_ip_prefix_list = "${google_compute_address.host_vm_pip[each.key].address}/32"
 
   local_as_number = var.edge_vm_asn
 

--- a/avxedge.tf
+++ b/avxedge.tf
@@ -7,7 +7,7 @@ resource "aviatrix_edge_spoke" "edge" {
   site_id                          = local.pov_edge_site
   ztp_file_type                    = "iso"
   ztp_file_download_path           = "${path.root}/${each.key}/"
-  management_egress_ip_prefix_list = "${google_compute_address.host_vm_pip[each.key].address}/32"
+  management_egress_ip_prefix_list = [format("%s/%s", google_compute_address.host_vm_pip[each.key].address, "32")]
 
   local_as_number = var.edge_vm_asn
 

--- a/avxedge.tf
+++ b/avxedge.tf
@@ -9,6 +9,7 @@ resource "aviatrix_edge_spoke" "edge" {
   ztp_file_download_path           = "${path.root}/${each.key}/"
   management_egress_ip_prefix_list = [format("%s/%s", google_compute_address.host_vm_pip[each.key].address, "32")]
 
+
   local_as_number = var.edge_vm_asn
 
   interfaces {
@@ -71,6 +72,9 @@ resource "aviatrix_edge_spoke_transit_attachment" "to_transit_gw" {
   transit_gw_name             = element(split("~", each.key), 1)
   enable_over_private_network = false
   number_of_retries           = 2
+  edge_wan_interfaces         = ["eth0"]
+  spoke_prepend_as_path       = []
+  transit_prepend_as_path     = []
 
   depends_on = [
     google_compute_instance.host_vm,

--- a/gcpnetwork.tf
+++ b/gcpnetwork.tf
@@ -25,6 +25,19 @@ resource "google_compute_firewall" "ssh" {
   source_ranges = local.host_ssh
 }
 
+resource "google_compute_firewall" "http" {
+  name    = "${local.test_vm_name}-ingress"
+  network = google_compute_network.vpc_network.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["test_instance"]
+}
+
 resource "google_compute_firewall" "allow_all" {
   name    = "${local.host_vpc_name}-allow-all"
   network = google_compute_network.vpc_network.name

--- a/gcpnetwork.tf
+++ b/gcpnetwork.tf
@@ -86,7 +86,7 @@ resource "google_compute_forwarding_rule" "forwarding_rule" {
 }
 
 resource "google_compute_route" "avx-edge-rfc10" {
-  name         = "avx-edge-rfc10"
+  name         = "${var.pov_prefix}-edge-rfc10"
   dest_range   = "10.0.0.0/8"
   network      = google_compute_network.vpc_network.name
   next_hop_ilb = google_compute_forwarding_rule.forwarding_rule.id
@@ -94,7 +94,7 @@ resource "google_compute_route" "avx-edge-rfc10" {
 }
 
 resource "google_compute_route" "avx-edge-rfc172" {
-  name         = "avx-edge-rfc172"
+  name         = "${var.pov_prefix}-edge-rfc172"
   dest_range   = "172.16.0.0/12"
   network      = google_compute_network.vpc_network.name
   next_hop_ilb = google_compute_forwarding_rule.forwarding_rule.id
@@ -102,7 +102,7 @@ resource "google_compute_route" "avx-edge-rfc172" {
 }
 
 resource "google_compute_route" "avx-edge-rfc192" {
-  name         = "avx-edge-rfc192"
+  name         = "${var.pov_prefix}-edge-rfc192"
   dest_range   = "192.168.0.0/16"
   network      = google_compute_network.vpc_network.name
   next_hop_ilb = google_compute_forwarding_rule.forwarding_rule.id

--- a/gcpnetwork.tf
+++ b/gcpnetwork.tf
@@ -35,7 +35,7 @@ resource "google_compute_firewall" "http" {
   }
 
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["test_instance"]
+  target_tags   = ["test-instance"]
 }
 
 resource "google_compute_firewall" "allow_all" {

--- a/gcpnetwork.tf
+++ b/gcpnetwork.tf
@@ -31,7 +31,7 @@ resource "google_compute_firewall" "http" {
 
   allow {
     protocol = "tcp"
-    ports    = ["80"]
+    ports    = var.test_vm_internet_ingress_ports
   }
 
   source_ranges = ["0.0.0.0/0"]

--- a/gcpstorage.tf
+++ b/gcpstorage.tf
@@ -124,11 +124,11 @@ resource "google_storage_bucket_object" "edge_ztp" {
 
   lifecycle {
     replace_triggered_by = [
-      aviatrix_edge_spoke.edge
+      aviatrix_edge_vm_selfmanaged.edge
     ]
   }
 
   depends_on = [
-    aviatrix_edge_spoke.edge
+    aviatrix_edge_vm_selfmanaged.edge
   ]
 }

--- a/gcptestvm.tf
+++ b/gcptestvm.tf
@@ -43,10 +43,10 @@ resource "google_compute_instance" "test_vm" {
     }
   }
 
+  metadata_startup_script = var.test_vm_metadata_startup_script
 
   metadata = {
-    user-data = file("${path.module}/test-cloud-init.yaml")
-    ssh-keys  = local.test_vm_ssh_key
+    ssh-keys = local.test_vm_ssh_key
   }
 
   lifecycle {

--- a/gcptestvm.tf
+++ b/gcptestvm.tf
@@ -48,7 +48,7 @@ resource "google_compute_instance" "test_vm" {
   metadata = {
     ssh-keys = local.test_vm_ssh_key
   }
-  tags = ["test_instance"]
+  tags = ["test-instance"]
 
   lifecycle {
     ignore_changes = [

--- a/gcptestvm.tf
+++ b/gcptestvm.tf
@@ -48,6 +48,7 @@ resource "google_compute_instance" "test_vm" {
   metadata = {
     ssh-keys = local.test_vm_ssh_key
   }
+  tags = ["test_instance"]
 
   lifecycle {
     ignore_changes = [

--- a/providers.tf
+++ b/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aviatrix = {
       source  = "aviatrixsystems/aviatrix"
-      version = ">= 2.24.0"
+      version = ">= 3.1.0"
     }
     google = {
       source = "hashicorp/google"

--- a/test-cloud-init.yaml
+++ b/test-cloud-init.yaml
@@ -1,8 +1,0 @@
-#cloud-config
-#basic just to add packages, install updates, reboot.
-packages:
-  - inetutils-traceroute
-  - iperf3
-  - plocate
-package_upgrade: true
-package_reboot_if_required: true

--- a/variables.tf
+++ b/variables.tf
@@ -190,5 +190,5 @@ locals {
     peer_ips       = [for peer_name, peer_obj in local.host_vms : peer_obj.lan_bridge_ip if my_obj.lan_bridge_ip != peer_obj.lan_bridge_ip]
   } }
 
-  edge_to_transit_gateways = toset(flatten([for edge in aviatrix_edge_spoke.edge : [for transit in var.transit_gateways : "${edge.gw_name}~${transit}"]]))
+  edge_to_transit_gateways = toset(flatten([for edge in aviatrix_edge_vm_selfmanaged.edge : [for transit in var.transit_gateways : "${edge.gw_name}~${transit}"]]))
 }

--- a/variables.tf
+++ b/variables.tf
@@ -162,7 +162,7 @@ locals {
     mgmt_dhcp_ip     = cidrhost(cidrsubnet(local.mgmt_cidr, local.mgmt_cidr_bits_to_subtract, i), 2)
     mgmt_xml         = "br-mgmt.xml"
 
-    edge_vm = "${var.pov_prefix}-edge-vm-${i + 1}"
+    edge_vm = "${var.pov_prefix}-edge-${i + 1}"
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -64,6 +64,11 @@ variable "test_vm_size" {
   default     = "e2-micro"
 }
 
+variable "test_vm_metadata_startup_script" {
+  description = "Metadata startup script"
+  default     = null
+}
+
 variable "vm_ssh_key" {
   description = "Host/Test VM Public Key in string form. Must include user@domain at the end of the key."
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -167,8 +167,9 @@ locals {
     mgmt_dhcp_ip     = cidrhost(cidrsubnet(local.mgmt_cidr, local.mgmt_cidr_bits_to_subtract, i), 2)
     mgmt_xml         = "br-mgmt.xml"
 
-    edge_vm = "${var.pov_prefix}-edge-${i + 1}"
-    }
+    # edge_vm = "${var.pov_prefix}-edge-${i + 1}"
+    edge_vm = "${var.pov_prefix}-edge-vm-${i + 1}"
+   }
   }
 
   frr_vxlan_confs = { for my_name, my_obj in local.host_vms : my_name => {

--- a/variables.tf
+++ b/variables.tf
@@ -64,6 +64,11 @@ variable "test_vm_size" {
   default     = "e2-micro"
 }
 
+variable "test_vm_internet_ingress_ports" {
+  description = "List of ports to allow Internet ingress to the test vm"
+  default     = []
+}
+
 variable "test_vm_metadata_startup_script" {
   description = "Metadata startup script"
   default     = null
@@ -169,7 +174,7 @@ locals {
 
     edge_vm = "${var.pov_prefix}-edge-${i + 1}"
 
-   }
+    }
   }
 
   frr_vxlan_confs = { for my_name, my_obj in local.host_vms : my_name => {

--- a/variables.tf
+++ b/variables.tf
@@ -167,8 +167,8 @@ locals {
     mgmt_dhcp_ip     = cidrhost(cidrsubnet(local.mgmt_cidr, local.mgmt_cidr_bits_to_subtract, i), 2)
     mgmt_xml         = "br-mgmt.xml"
 
-    # edge_vm = "${var.pov_prefix}-edge-${i + 1}"
-    edge_vm = "${var.pov_prefix}-edge-vm-${i + 1}"
+    edge_vm = "${var.pov_prefix}-edge-${i + 1}"
+
    }
   }
 


### PR DESCRIPTION
- Require `aviatrixsystems/aviatrix` >= 3.1.0
- Updated 3.1.0 syntax for `aviatrix_edge_spoke_gateway` arguments
- Add pov_prefix to rfc1918 routes to avoid collision when more than one edge is deployed to the same gcp project
- Accept custom startup script for the test vm via `test_vm_metadata_startup_script parameter`
- Add `management_egress_ip_prefix_list` argument for `aviatrix_edge_spoke_gateway` to automatically add edge public IP to controller security group
