### PR TITLE
Generic ssh to enable post deploy automation

### DIFF
--- a/gcptestvm.tf
+++ b/gcptestvm.tf
@@ -46,7 +46,7 @@ resource "google_compute_instance" "test_vm" {
   metadata_startup_script = var.test_vm_metadata_startup_script
 
   metadata = {
-    ssh-keys = local.test_vm_ssh_key
+    ssh-keys = "ubuntu:${var.vm_ssh_key}"
   }
   tags = ["test-instance"]
 

--- a/output.tf
+++ b/output.tf
@@ -12,3 +12,8 @@ output "test_vm_pip" {
   description = "Host and edge VM details."
   value       = google_compute_address.test_vm_pip
 }
+
+output "test_vm_int_ip" {
+  description = "Test vm internal ip."
+  value       = local.test_vm_vpc_ip
+}


### PR DESCRIPTION
- Facilitate post-deploy automation by changing to a generic ssh key for the test vm
- Output the private ip of the test instance