### PR TITLE
Update the ip address url

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ provider "google" {
 }
 
 data "http" "myip" {
-  url = "http://ifconfig.me"
+  url = "https://ipv4.icanhazip.com/"
 }
 
 module "edge" {

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ resource "local_sensitive_file" "root_ssh" {
 
 #Need to let Terraform contact the host VMs.
 data "http" "my_pip" {
-  url = "http://ifconfig.me"
+  url = "https://ipv4.icanhazip.com/"
 }
 
 resource "local_file" "libvirt_br_wan_xml" {

--- a/variables.tf
+++ b/variables.tf
@@ -110,7 +110,7 @@ locals {
 
   host_vpc_name    = "${var.pov_prefix}-vpc"
   host_subnet_name = "${var.pov_prefix}-subnet"
-  host_ssh         = concat(["35.235.240.0/20", data.http.my_pip.response_body], var.admin_cidr) #GCP IAP prefix for portal ssh
+  host_ssh         = concat(["35.235.240.0/20", "${chomp(data.http.my_pip.response_body)}/32"], var.admin_cidr) #GCP IAP prefix for portal ssh
   #host_ssh         = concat(["35.235.240.0/20", data.http.my_public_ip.response_body ], var.admin_cidr)  #GCP IAP prefix for portal ssh
   host_allow_all = concat([var.host_vm_cidr, "130.211.0.0/22", "35.191.0.0/16"], var.external_cidrs) #We allow all from the external cidrs and the host_vm_cidr itself.
   host_vm_prefix = "${var.pov_prefix}-host"


### PR DESCRIPTION
*What?*
- Update the ip address url to be more accurate.

*Why?*
- The previous ip address url would capture the ipv6 address, which led to pod deployment failure. 