### PR TITLE
Move qcow to the cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,50 @@
 # gcp-edge-demo
 
-Deploy Aviatrix Edge 2.0 in GCP (and eventually Azure.) AWS doesn't support nested virtualization, except on .metal instances.
+Deploy Aviatrix Edge GCP. AWS doesn't support nested virtualization, except on .metal instances.
 
 ## Software Requirements
 
 Terraform
 Google Cloud SDK/GCloud CLI: Must use **gcloud init** and **gcloud auth application-default login**.
 
-## Other requirements
+## Compatibility
 
-The IP of the Edge Host VMs must be allowed to connect to the controller on port 443. The example below shows GCP.
+| Module version | Terraform version | Controller version | Terraform provider version |
+| :------------- | :---------------- | :----------------- | :------------------------- |
+| v3.1.4         | >= 1.3.0          | >= 7.1             | ~>3.1.0                    |
+
+## Module Attributes
+
+### Required
+  
+  | key                 | value                                                                                   |
+  | :------------------ | :-------------------------------------------------------------------------------------- |
+  |                     |
+  | source              | "terraform-aviatrix-modules/gcp-edge-demo/aviatrix"                                     |
+  | version             | "3.1.4"                                                                                 |
+  | edge_image_location | gcp_bucket/filename.qcow2                                                               |
+  | edge_image_filename | ${path.module}/filename.qcow2                                                           |
+  | vm_ssh_key          | Host/Test VM Public Key in string form. Must include user@domain at the end of the key. |
+
+*NOTE: `edge_image_location` and `edge_image_filename` are mutually exclusive, but one is required.
+
+### Optional
+
+| key                             | value                                                                                                                                                     |
+| :------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| admin_cidr                      | CIDRs that can SSH to the Host VMs. For GCP, the IAP range is always allowed.                                                                             |
+| region                          | Define the region for the VM and Storage Account. "us-central1" is the default                                                                            |
+| pov_prefix                      | Name prefix to prepend to all created resources. Default is "avx"                                                                                         |
+| host_vm_size                    | Must be capable of virtualization. Default is "n2-standard-2"                                                                                             |
+| host_vm_cidr                    | /28 is minimum size. Only need 3 IPs - 2x host VM plus ILB. Default is "10.40.251.16/28"                                                                  |
+| host_vm_asn                     | ASN for the host VMs. Default is "64900"                                                                                                                  |
+| host_vm_count                   | Number of host VMs (and Edge VMs) to deploy. Default is "2"                                                                                               |
+| test_vm_size                    | "Test VM size. Default is "e2-micro"                                                                                                                      |
+| edge_vm_asn                     | ASN for Edge instances. Default is "64581"                                                                                                                |
+| edge_lan_cidr                   | The bridges on each host are connected at Layer 2 using VXLAN. 2 IPs per host VM. Default is "10.40.251.0/29"                                             |
+| test_vm_metadata_startup_script | Metadata startup script for the test vm. Default is `null`                                                                                                |
+| external_cidrs                  | List of CIDRs that the Host VM should advertise into Edge. Static routes within the host VM will direct traffic to the subnet default gw. Default is "[]" |
+| transit_gateways                | List of Transit Gateways to add edge attachments. Default is "[]"                                                                                         |
 
 ## Example
 
@@ -41,7 +76,7 @@ data "http" "myip" {
 
 module "edge" {
   source                          = "terraform-aviatrix-modules/gcp-edge-demo/aviatrix"
-  version                         = "3.1.1"
+  version                         = "3.1.4"
   admin_cidr                      = ["${chomp(data.http.myip.response_body)}/32"]
   region                          = "us-west2"
   pov_prefix                      = "us-west2-demo"
@@ -53,10 +88,10 @@ module "edge" {
   host_vm_count                   = 1
   edge_vm_asn                     = 64581
   edge_lan_cidr                   = "10.40.251.0/29"
-  edge_image_filename             = "${path.module}/avx-edge-kvm-7.1-2023-04-24.qcow2"
+  edge_image_location             = "gcp_bucket/avx-edge-kvm-7.1-2023-04-24.qcow2"
   test_vm_metadata_startup_script = null
-  external_cidrs = []
-  vm_ssh_key     = file("~/.ssh/id_rsa.pub")
-  transit_gateways = []
+  external_cidrs                  = []
+  vm_ssh_key                      = file("~/.ssh/id_rsa.pub")
+  transit_gateways                = []
 }
 ```

--- a/gcphostvm.tf
+++ b/gcphostvm.tf
@@ -56,12 +56,6 @@ resource "google_compute_instance" "host_vm" {
     edge-vm-name       = each.value.edge_vm
   }
 
-  # lifecycle {
-  #   ignore_changes = [
-  #     metadata["ssh-keys"]
-  #   ]
-  # }
-
   depends_on = [
     google_storage_bucket_object.libvirt_br_wan_xml,
     google_storage_bucket_object.libvirt_br_lan_xml,
@@ -70,7 +64,7 @@ resource "google_compute_instance" "host_vm" {
     google_storage_bucket_object.libvirt_hook_network,
     google_storage_bucket_object.startup_script,
     google_storage_bucket_object.frr_conf,
-    google_storage_bucket_object.qcow2,
+    google_storage_bucket_object.qcow2[0],
     google_storage_bucket_object.edge_ztp
   ]
 }

--- a/gcpstorage.tf
+++ b/gcpstorage.tf
@@ -109,7 +109,9 @@ resource "google_storage_bucket_object" "frr_conf" {
   }
 }
 
+# Block this resource from being created if the edge_image_location is set.
 resource "google_storage_bucket_object" "qcow2" {
+  count  = var.edge_image_location == "" ? 0 : 1
   name   = "edge.qcow2"
   source = var.edge_image_filename
   bucket = google_storage_bucket.bucket.name

--- a/gcpstorage.tf
+++ b/gcpstorage.tf
@@ -111,7 +111,7 @@ resource "google_storage_bucket_object" "frr_conf" {
 
 # Block this resource from being created if the edge_image_location is set.
 resource "google_storage_bucket_object" "qcow2" {
-  count  = var.edge_image_location == "" ? 1 : 0
+  count  = var.edge_image_location == null ? 1 : 0
   name   = basename(var.edge_image_filename)
   source = var.edge_image_filename
   bucket = google_storage_bucket.bucket.name

--- a/gcpstorage.tf
+++ b/gcpstorage.tf
@@ -112,7 +112,7 @@ resource "google_storage_bucket_object" "frr_conf" {
 # Block this resource from being created if the edge_image_location is set.
 resource "google_storage_bucket_object" "qcow2" {
   count  = var.edge_image_location == "" ? 1 : 0
-  name   = var.edge_image_filename
+  name   = basename(var.edge_image_filename)
   source = var.edge_image_filename
   bucket = google_storage_bucket.bucket.name
 }

--- a/gcpstorage.tf
+++ b/gcpstorage.tf
@@ -112,7 +112,7 @@ resource "google_storage_bucket_object" "frr_conf" {
 # Block this resource from being created if the edge_image_location is set.
 resource "google_storage_bucket_object" "qcow2" {
   count  = var.edge_image_location == "" ? 1 : 0
-  name   = "edge.qcow2"
+  name   = var.edge_image_filename
   source = var.edge_image_filename
   bucket = google_storage_bucket.bucket.name
 }

--- a/gcpstorage.tf
+++ b/gcpstorage.tf
@@ -111,7 +111,7 @@ resource "google_storage_bucket_object" "frr_conf" {
 
 # Block this resource from being created if the edge_image_location is set.
 resource "google_storage_bucket_object" "qcow2" {
-  count  = var.edge_image_location == "" ? 0 : 1
+  count  = var.edge_image_location == "" ? 1 : 0
   name   = "edge.qcow2"
   source = var.edge_image_filename
   bucket = google_storage_bucket.bucket.name

--- a/startup-sh.tftpl
+++ b/startup-sh.tftpl
@@ -15,7 +15,7 @@ if [ ! -f /var/lib/libvirt/images/edge.qcow2 ]; then
   mkdir -p var/lib/libvirt/images
   while :; do
     #Edge Qcow2?
-    gsutil cp gs://${bucket}/edge.qcow2 /var/lib/libvirt/images/.
+    gsutil cp gs://${edge_bucket}/edge.qcow2 /var/lib/libvirt/images/.
     if [ $? -ne 0 ]; then
       echo "Warning: edge.qcow2 not in bucket."
       sleep 60 #Sleep 1 min

--- a/startup-sh.tftpl
+++ b/startup-sh.tftpl
@@ -11,17 +11,17 @@ fi
 
 # Download Edge.qcow2
 # We only get the qcow2 and ztp if the qcow2 is missing.
-if [ ! -f /var/lib/libvirt/images/edge.qcow2 ]; then
+if [ ! -f /var/lib/libvirt/images/$edge_image_name ]; then
   mkdir -p var/lib/libvirt/images
   while :; do
     #Edge Qcow2?
-    gsutil cp gs://${edge_bucket}/edge.qcow2 /var/lib/libvirt/images/.
+    gsutil cp gs://${edge_bucket}/${edge_image_name} /var/lib/libvirt/images/.
     if [ $? -ne 0 ]; then
-      echo "Warning: edge.qcow2 not in bucket."
+      echo "Warning: $edge_image_name not in bucket."
       sleep 60 #Sleep 1 min
       continue
     else
-      echo "edge.qcow2 downloaded."
+      echo "$edge_image_name downloaded."
       break
     fi
   done

--- a/startup-sh.tftpl
+++ b/startup-sh.tftpl
@@ -11,17 +11,17 @@ fi
 
 # Download Edge.qcow2
 # We only get the qcow2 and ztp if the qcow2 is missing.
-if [ ! -f /var/lib/libvirt/images/$edge_image_name ]; then
+if [ ! -f /var/lib/libvirt/images/${edge_image_name} ]; then
   mkdir -p var/lib/libvirt/images
   while :; do
     #Edge Qcow2?
     gsutil cp gs://${edge_bucket}/${edge_image_name} /var/lib/libvirt/images/.
     if [ $? -ne 0 ]; then
-      echo "Warning: $edge_image_name not in bucket."
+      echo "Warning: ${edge_image_name} not in bucket."
       sleep 60 #Sleep 1 min
       continue
     else
-      echo "$edge_image_name downloaded."
+      echo "${edge_image_name} downloaded."
       break
     fi
   done

--- a/variables.tf
+++ b/variables.tf
@@ -72,9 +72,11 @@ variable "edge_image_filename" {
 variable "edge_image_location" {
   type        = string
   description = "GCP Storage bucket location for the Edge image"
+  default     = null
 
+  # Only runs the validation if the edge_image_location is set.
   validation {
-    condition     = can(regex("^[^/]+/[^/]+$", var.edge_image_location))
+    condition     = var.edge_image_location == null ? true : can(regex("^[^/]+/[^/]+$", var.edge_image_location))
     error_message = "Edge image location should be in the format <bucket_name>/<edge_image_name>.qcow2"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -141,7 +141,7 @@ locals {
 
     edge_bucket = var.edge_image_location == "" ? google_storage_bucket.bucket.name : var.edge_image_location
 
-    edge_image_name = var.edge_image_filename
+    edge_image_name = basename(var.edge_image_filename)
 
     wan_prefix_size = local.wan_prefix_size
     wan_bridge_ip   = cidrhost(cidrsubnet(local.wan_cidr, local.wan_cidr_bits_to_subtract, i), 1)

--- a/variables.tf
+++ b/variables.tf
@@ -70,11 +70,10 @@ variable "edge_image_filename" {
 }
 
 variable "edge_image_location" {
-  type = string
+  type        = string
   description = "GCP Storage bucket location for the Edge image"
-  default     = ""
 
-   validation {
+  validation {
     condition     = can(regex("^[^/]+/[^/]+$", var.edge_image_location))
     error_message = "Edge image location should be in the format <bucket_name>/<edge_image_name>.qcow2"
   }
@@ -97,8 +96,8 @@ locals {
   host_vpc_name    = "${var.pov_prefix}-vpc"
   host_subnet_name = "${var.pov_prefix}-subnet"
   host_ssh         = concat(["35.235.240.0/20", "${chomp(data.http.my_pip.response_body)}/32"], var.admin_cidr) #GCP IAP prefix for portal ssh
-  host_allow_all = concat([var.host_vm_cidr, "130.211.0.0/22", "35.191.0.0/16"], var.external_cidrs) #We allow all from the external cidrs and the host_vm_cidr itself.
-  host_vm_prefix = "${var.pov_prefix}-host"
+  host_allow_all   = concat([var.host_vm_cidr, "130.211.0.0/22", "35.191.0.0/16"], var.external_cidrs)          #We allow all from the external cidrs and the host_vm_cidr itself.
+  host_vm_prefix   = "${var.pov_prefix}-host"
 
   test_vm_name = "${var.pov_prefix}-test-vm"
 
@@ -139,16 +138,16 @@ locals {
 
     host_vm  = "${var.pov_prefix}-host-vm-${i + 1}"
     host_asn = var.host_vm_asn
-    
+
     vpc_ip = cidrhost(var.host_vm_cidr, i + 3) #Right after the ILB
 
     bucket = google_storage_bucket.bucket.name
 
     # Name of the bucket that stores the edge image.
-    edge_bucket = var.edge_image_location == "" ? google_storage_bucket.bucket.name: split("/", var.edge_image_location)[0]
+    edge_bucket = var.edge_image_location == null ? google_storage_bucket.bucket.name : split("/", var.edge_image_location)[0]
 
     # Name of the edge image in the format <edge_image_name>.qcow2.
-    edge_image_name = var.edge_image_location == "" ? basename(var.edge_image_filename) : split("/", var.edge_image_location)[1]
+    edge_image_name = var.edge_image_location == null ? basename(var.edge_image_filename) : split("/", var.edge_image_location)[1]
 
     wan_prefix_size = local.wan_prefix_size
     wan_bridge_ip   = cidrhost(cidrsubnet(local.wan_cidr, local.wan_cidr_bits_to_subtract, i), 1)

--- a/variables.tf
+++ b/variables.tf
@@ -66,7 +66,7 @@ variable "edge_lan_cidr" {
 
 variable "edge_image_filename" {
   description = "Edge image filename"
-  default     = "avx-edge-gateway-kvm-2022-08-31-6.8.qcow2"
+  default     = "edge.qcow2"
 }
 
 variable "edge_image_location" {
@@ -140,6 +140,8 @@ locals {
     bucket = google_storage_bucket.bucket.name
 
     edge_bucket = var.edge_image_location == "" ? google_storage_bucket.bucket.name : var.edge_image_location
+
+    edge_image_name = var.edge_image_filename
 
     wan_prefix_size = local.wan_prefix_size
     wan_bridge_ip   = cidrhost(cidrsubnet(local.wan_cidr, local.wan_cidr_bits_to_subtract, i), 1)

--- a/variables.tf
+++ b/variables.tf
@@ -66,13 +66,18 @@ variable "edge_lan_cidr" {
 
 variable "edge_image_filename" {
   description = "Edge image filename"
-  default     = "edge.qcow2"
+  default     = ""
 }
 
 variable "edge_image_location" {
   type = string
   description = "GCP Storage bucket location for the Edge image"
   default     = ""
+
+   validation {
+    condition     = can(regex("^[a-zA-Z0-9]+\\/[a-zA-Z0-9]+$", var.edge_image_location))
+    error_message = "Edge image location should be in the format <bucket_name>/<edge_image_name>.qcow2"
+  }
 }
 
 variable "external_cidrs" {

--- a/variables.tf
+++ b/variables.tf
@@ -144,9 +144,11 @@ locals {
 
     bucket = google_storage_bucket.bucket.name
 
-    edge_bucket = var.edge_image_location == "" ? google_storage_bucket.bucket.name : var.edge_image_location
+    # Name of the bucket that stores the edge image.
+    edge_bucket = var.edge_image_location == "" ? google_storage_bucket.bucket.name: split("/", var.edge_image_location)[0]
 
-    edge_image_name = basename(var.edge_image_filename)
+    # Name of the edge image in the format <edge_image_name>.qcow2.
+    edge_image_name = var.edge_image_location == "" ? basename(var.edge_image_filename) : split("/", var.edge_image_location)[1]
 
     wan_prefix_size = local.wan_prefix_size
     wan_bridge_ip   = cidrhost(cidrsubnet(local.wan_cidr, local.wan_cidr_bits_to_subtract, i), 1)

--- a/variables.tf
+++ b/variables.tf
@@ -75,7 +75,7 @@ variable "edge_image_location" {
   default     = ""
 
    validation {
-    condition     = can(regex("^[a-zA-Z0-9]+\\/[a-zA-Z0-9]+$", var.edge_image_location))
+    condition     = can(regex("^[^/]+/[^/]+$", var.edge_image_location))
     error_message = "Edge image location should be in the format <bucket_name>/<edge_image_name>.qcow2"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -70,8 +70,9 @@ variable "edge_image_filename" {
 }
 
 variable "edge_image_location" {
-  description = "GCP Storage bucket location for the Edge image"
   type = string
+  description = "GCP Storage bucket location for the Edge image"
+  default     = ""
 }
 
 variable "external_cidrs" {
@@ -138,7 +139,7 @@ locals {
 
     bucket = google_storage_bucket.bucket.name
 
-    edge_bucket = var.edge_image_location == "" ? bucket : var.edge_image_location
+    edge_bucket = var.edge_image_location == "" ? google_storage_bucket.bucket.name : var.edge_image_location
 
     wan_prefix_size = local.wan_prefix_size
     wan_bridge_ip   = cidrhost(cidrsubnet(local.wan_cidr, local.wan_cidr_bits_to_subtract, i), 1)

--- a/vm.tftpl
+++ b/vm.tftpl
@@ -30,7 +30,7 @@
     <emulator>/usr/bin/qemu-system-x86_64</emulator>
     <disk type="file" device="disk">
       <driver name="qemu" type="qcow2"/>
-      <source file="/var/lib/libvirt/images/edge.qcow2"/>
+      <source file="/var/lib/libvirt/images/$edge_image_name"/>
       <target dev="vda" bus="virtio"/>
     </disk>
     <disk type="file" device="cdrom">

--- a/vm.tftpl
+++ b/vm.tftpl
@@ -30,7 +30,7 @@
     <emulator>/usr/bin/qemu-system-x86_64</emulator>
     <disk type="file" device="disk">
       <driver name="qemu" type="qcow2"/>
-      <source file="/var/lib/libvirt/images/$edge_image_name"/>
+      <source file="/var/lib/libvirt/images/${edge_image_name}"/>
       <target dev="vda" bus="virtio"/>
     </disk>
     <disk type="file" device="cdrom">


### PR DESCRIPTION
*What?*
- Move the qcow to the cloud.

*Why?*
- This will cause less burden on our local machines to read the file and will be easier to change the file when needed.

*Testing*
- I deployed a demo event with only the edge_image_location set.
- I deployed a demo event with both edge_image_location and edge_image_filename set.
- I deployed a demo event with only the edge_image_filename set.
