### PR TITLE
Edge resource naming convention update

### DIFF
--- a/avxedge.tf
+++ b/avxedge.tf
@@ -1,6 +1,6 @@
 # Deploy Avx Edge Gateways in Controller, download ZTP.
 
-resource "aviatrix_edge_vm_selfmanaged" "edge" {
+resource "aviatrix_edge_gateway_selfmanaged" "edge" {
   for_each = local.host_vms
 
   gw_name                          = each.value.edge_vm
@@ -60,7 +60,7 @@ resource "aviatrix_edge_spoke_external_device_conn" "to_host_vm" {
 
   depends_on = [
     google_compute_instance.host_vm,
-    aviatrix_edge_vm_selfmanaged.edge
+    aviatrix_edge_gateway_selfmanaged.edge
   ]
 }
 
@@ -78,6 +78,6 @@ resource "aviatrix_edge_spoke_transit_attachment" "to_transit_gw" {
 
   depends_on = [
     google_compute_instance.host_vm,
-    aviatrix_edge_vm_selfmanaged.edge
+    aviatrix_edge_gateway_selfmanaged.edge
   ]
 }

--- a/gcpstorage.tf
+++ b/gcpstorage.tf
@@ -126,11 +126,11 @@ resource "google_storage_bucket_object" "edge_ztp" {
 
   lifecycle {
     replace_triggered_by = [
-      aviatrix_edge_vm_selfmanaged.edge
+      aviatrix_edge_gateway_selfmanaged.edge
     ]
   }
 
   depends_on = [
-    aviatrix_edge_vm_selfmanaged.edge
+    aviatrix_edge_gateway_selfmanaged.edge
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -187,5 +187,5 @@ locals {
     peer_ips       = [for peer_name, peer_obj in local.host_vms : peer_obj.lan_bridge_ip if my_obj.lan_bridge_ip != peer_obj.lan_bridge_ip]
   } }
 
-  edge_to_transit_gateways = toset(flatten([for edge in aviatrix_edge_vm_selfmanaged.edge : [for transit in var.transit_gateways : "${edge.gw_name}~${transit}"]]))
+  edge_to_transit_gateways = toset(flatten([for edge in aviatrix_edge_gateway_selfmanaged.edge : [for transit in var.transit_gateways : "${edge.gw_name}~${transit}"]]))
 }


### PR DESCRIPTION
Resource `aviatrix_edge_vm_selfmanaged` will be deprecated in the `3.2.0` release of the Aviatrix terraform provider. Functionally equivalent and validated with `3.1.4`.