### PR TITLE
Exposing edge attachment retry config and randomizing gcp bucket name

### DIFF
--- a/avxedge.tf
+++ b/avxedge.tf
@@ -56,7 +56,8 @@ resource "aviatrix_edge_spoke_external_device_conn" "to_host_vm" {
   bgp_remote_as_num = var.host_vm_asn
   local_lan_ip      = each.value.lan_edge_ip
   remote_lan_ip     = each.value.lan_bridge_ip
-  number_of_retries = 2
+  number_of_retries = var.number_of_retries
+  retry_interval    = var.retry_interval
 
   depends_on = [
     google_compute_instance.host_vm,

--- a/gcpstorage.tf
+++ b/gcpstorage.tf
@@ -4,8 +4,15 @@
 # The Project Owners/Editors have read/write.
 # The Compute Engine default as well as a few other accounts have read access.
 # This default is fine for this deployment.
+resource "random_string" "random" {
+  length           = 8
+  upper            = false
+  special          = true
+  override_special = "-_"
+}
+
 resource "google_storage_bucket" "bucket" {
-  name     = local.storage_name
+  name     = "avx-${random_string.random.id}-edge-bucket"
   location = var.region
 
   uniform_bucket_level_access = true

--- a/variables.tf
+++ b/variables.tf
@@ -96,6 +96,16 @@ variable "gcp_ubuntu_image" {
   default     = "projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20240607"
 }
 
+variable "number_of_retries" {
+  description = "Number of retries for aviatrix_edge_spoke_external_device_conn"
+  default     = 3
+
+}
+variable "retry_interval" {
+  description = "Retry interval for aviatrix_edge_spoke_external_device_conn"
+  default     = 300
+}
+
 # Locals/computed
 locals {
   pov_edge_site = "${var.pov_prefix}-edge-site"
@@ -114,7 +124,6 @@ locals {
 
   edge_vm_prefix = "${var.pov_prefix}-edge"
 
-  storage_name         = "${var.pov_prefix}-edge-bucket"
   backend_service_name = "${var.pov_prefix}-backend-service"
   hc_name              = "${var.pov_prefix}-edge-bgp-hc"
   forwarding_rule_name = "${var.pov_prefix}-edge-forwarding-rule"


### PR DESCRIPTION
Randomizing the gcp edge bucket name to avoid naming collisions.
Exposing `retry_interval` and `number_of_retries` attributes of the `aviatrix_edge_spoke_external_device_conn` resource as configurable parameters.