### PR TITLE
Add choice for host bgp connectivity

### DIFF
--- a/avxedge.tf
+++ b/avxedge.tf
@@ -47,7 +47,7 @@ resource "aviatrix_edge_gateway_selfmanaged" "edge" {
 
 # Connect Edge VMs to host VMs with BGPoLAN
 resource "aviatrix_edge_spoke_external_device_conn" "to_host_vm" {
-  for_each = local.host_vms
+  for_each = { for k, v in local.host_vms : k => v if var.connect_host_bgp }
 
   site_id           = local.pov_edge_site
   connection_name   = "${each.value.edge_vm}-to-${each.key}"

--- a/variables.tf
+++ b/variables.tf
@@ -116,6 +116,11 @@ variable "hpe_tunnel_number" {
   default     = 2
 }
 
+variable "connect_host_bgp" {
+  description = "Connect edge spokes to host VMs using BGP"
+  default     = true
+}
+
 # Locals/computed
 locals {
   pov_edge_site = "${var.pov_prefix}-edge-site"


### PR DESCRIPTION
Adds a variable to choose whether to connect the edge spoke to the host vm via bgp (for training use-cases that have the student create the external connection via CoPilot).