### PR TITLE
[AVXIT-10782] fix: edge ztp iso bug

### DIFF
--- a/avxedge.tf
+++ b/avxedge.tf
@@ -111,6 +111,10 @@ resource "aviatrix_edge_spoke_transit_attachment" "to_transit_gw" {
   enable_insane_mode          = var.enable_hpe_spoke
   insane_mode_tunnel_number   = var.enable_hpe_spoke ? var.hpe_tunnel_number : null
 
+  lifecycle {
+    replace_triggered_by = [null_resource.always_trigger]
+  }
+
   depends_on = [
     google_compute_instance.host_vm,
     aviatrix_edge_gateway_selfmanaged.edge,

--- a/avxedge.tf
+++ b/avxedge.tf
@@ -1,5 +1,11 @@
 # Deploy Avx Edge Gateways in Controller, download ZTP.
 
+resource "null_resource" "always_trigger" {
+  triggers = {
+    always_run = timestamp()
+  }
+}
+
 resource "aviatrix_edge_gateway_selfmanaged" "edge" {
   for_each = local.host_vms
 
@@ -11,6 +17,10 @@ resource "aviatrix_edge_gateway_selfmanaged" "edge" {
 
 
   local_as_number = var.edge_vm_asn
+
+  lifecycle {
+    replace_triggered_by = [null_resource.always_trigger]
+  }
 
   interfaces {
     name          = "eth0"

--- a/avxedge.tf
+++ b/avxedge.tf
@@ -87,6 +87,10 @@ resource "aviatrix_edge_spoke_external_device_conn" "to_host_vm" {
   number_of_retries = var.number_of_retries
   retry_interval    = var.retry_interval
 
+  lifecycle {
+    replace_triggered_by = [null_resource.always_trigger]
+  }
+
   depends_on = [
     google_compute_instance.host_vm,
     aviatrix_edge_gateway_selfmanaged.edge


### PR DESCRIPTION
*What?*
- Added wait provisioner.
- Added lifecycle to self managed edge resource.
- Added lifecycle to device connections. 

*Why?*
- The provisioner would ensure the the iso files exist before uploading the files into an S3 bucket.
- The life cycles are required due to existing connections that interfere with destruction of the self managed host during recreation.

### Testing
#### Deployed edge instances in multiple cloud accounts
![Screenshot 2025-04-14 at 5 51 53 PM](https://github.com/user-attachments/assets/ca7b9ae2-b81e-47f1-b862-1ccb100eedfc)
![Screenshot 2025-04-14 at 5 52 15 PM](https://github.com/user-attachments/assets/1fccb582-b794-47cb-8e7e-67366f3d427d)

#### Deployed using local qcow file
![Screenshot 2025-04-14 at 6 01 36 PM](https://github.com/user-attachments/assets/3d2eef97-58ae-41f4-87da-7d141de7950e)

#### Redeployed terraform
![Screenshot 2025-04-14 at 10 38 43 PM](https://github.com/user-attachments/assets/ff664c12-5e8d-4b85-bc24-4b0100da0def)
![Screenshot 2025-04-14 at 11 21 16 PM](https://github.com/user-attachments/assets/8eb65662-e48e-4db2-b35a-ab3a2e141a5f)